### PR TITLE
fix: Handle unsupported audio files gracefully to prevent crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
  "symphonia-codec-adpcm",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
@@ -3806,6 +3807,17 @@ dependencies = [
  "log",
  "symphonia-core",
  "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbf25b545ad0d3ee3e891ea643ad115aff4ca92f6aec472086b957a58522f70"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ log = { version = "0.4", features = ["release_max_level_info"] }
 walkdir = "2.5"
 rubato = "0.12.0"
 rand = "0.8.5"
-symphonia = { version = "0.5.4", features = ["mp3"] }
+symphonia = { version = "0.5.4", features = ["mp3", "flac", "wav", "aac", "ogg", "vorbis"] }
 arrayvec = "0.7.4"
 rb = "0.4.1"
 image = "0.24"

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -50,9 +50,11 @@ impl Player {
         self.selected_track = track;
 
         if let Some(track) = &self.selected_track {
-            self.audio_tx
-                .send(AudioCommand::LoadFile(track.path()))
-                .expect("Failed to send select to audio thread");
+            if let Err(e) = self.audio_tx.send(AudioCommand::LoadFile(track.path())) {
+                tracing::error!("Failed to send select to audio thread: {}", e);
+                // Audio thread is likely dead, mark as stopped
+                self.track_state = TrackState::Stopped;
+            }
         }
     }
 
@@ -62,9 +64,11 @@ impl Player {
 
     pub fn seek_to(&mut self, seek_to_timestamp: u64) {
         self.seek_to_timestamp = seek_to_timestamp;
-        self.audio_tx
-            .send(AudioCommand::Seek(seek_to_timestamp))
-            .expect("Failed to send seek to audio thread");
+        if let Err(e) = self.audio_tx.send(AudioCommand::Seek(seek_to_timestamp)) {
+            tracing::error!("Failed to send seek to audio thread: {}", e);
+            // Audio thread is likely dead, mark as stopped
+            self.track_state = TrackState::Stopped;
+        }
     }
 
     // TODO: Should return Result
@@ -72,9 +76,10 @@ impl Player {
         match &self.track_state {
             TrackState::Playing | TrackState::Paused => {
                 self.track_state = TrackState::Stopped;
-                self.audio_tx
-                    .send(AudioCommand::Stop)
-                    .expect("Failed to send stop to audio thread");
+                if let Err(e) = self.audio_tx.send(AudioCommand::Stop) {
+                    tracing::error!("Failed to send stop to audio thread: {}", e);
+                    // Audio thread is likely dead, state already set to stopped
+                }
             }
             _ => (),
         }
@@ -87,15 +92,17 @@ impl Player {
                 TrackState::Unstarted | TrackState::Stopped | TrackState::Playing => {
                     self.track_state = TrackState::Playing;
 
-                    self.audio_tx
-                        .send(AudioCommand::Play)
-                        .expect("Failed to send play to audio thread");
+                    if let Err(e) = self.audio_tx.send(AudioCommand::Play) {
+                        tracing::error!("Failed to send play to audio thread: {}", e);
+                        self.track_state = TrackState::Stopped;
+                    }
                 }
                 TrackState::Paused => {
                     self.track_state = TrackState::Playing;
-                    self.audio_tx
-                        .send(AudioCommand::Play)
-                        .expect("Failed to send play to audio thread");
+                    if let Err(e) = self.audio_tx.send(AudioCommand::Play) {
+                        tracing::error!("Failed to send play to audio thread: {}", e);
+                        self.track_state = TrackState::Stopped;
+                    }
                 }
             }
         }
@@ -106,15 +113,17 @@ impl Player {
         match self.track_state {
             TrackState::Playing => {
                 self.track_state = TrackState::Paused;
-                self.audio_tx
-                    .send(AudioCommand::Pause)
-                    .expect("Failed to send pause to audio thread");
+                if let Err(e) = self.audio_tx.send(AudioCommand::Pause) {
+                    tracing::error!("Failed to send pause to audio thread: {}", e);
+                    self.track_state = TrackState::Stopped;
+                }
             }
             TrackState::Paused => {
                 self.track_state = TrackState::Playing;
-                self.audio_tx
-                    .send(AudioCommand::Play)
-                    .expect("Failed to send play to audio thread");
+                if let Err(e) = self.audio_tx.send(AudioCommand::Play) {
+                    tracing::error!("Failed to send play to audio thread: {}", e);
+                    self.track_state = TrackState::Stopped;
+                }
             }
             _ => (),
         }
@@ -177,9 +186,10 @@ impl Player {
         if !is_processing_ui_change.load(Ordering::Acquire) {
             is_processing_ui_change.store(true, Ordering::Release);
             self.volume = volume;
-            self.audio_tx
-                .send(AudioCommand::SetVolume(volume))
-                .expect("Failed to send play to audio thread");
+            if let Err(e) = self.audio_tx.send(AudioCommand::SetVolume(volume)) {
+                tracing::error!("Failed to send volume to audio thread: {}", e);
+                self.track_state = TrackState::Stopped;
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,8 +154,31 @@ fn main() {
                             break 'once Ok(());
                         }
 
-                        let reader = audio_engine_state.reader.as_mut().unwrap();
-                        let play_opts = audio_engine_state.track_info.unwrap();
+                        // Check if we have a valid reader and track info before proceeding
+                        let reader = match audio_engine_state.reader.as_mut() {
+                            Some(reader) => reader,
+                            None => {
+                                tracing::warn!("AudioThread Playing - No reader available, switching to stopped");
+                                state = PlayerState::Stopped;
+                                ui_tx
+                                    .send(UiCommand::AudioFinished)
+                                    .expect("Failed to send audio finished to ui thread");
+                                break 'once Ok(());
+                            }
+                        };
+
+                        let play_opts = match audio_engine_state.track_info {
+                            Some(opts) => opts,
+                            None => {
+                                tracing::warn!("AudioThread Playing - No track info available, switching to stopped");
+                                state = PlayerState::Stopped;
+                                ui_tx
+                                    .send(UiCommand::AudioFinished)
+                                    .expect("Failed to send audio finished to ui thread");
+                                break 'once Ok(());
+                            }
+                        };
+
                         let audio_output = &mut audio_engine_state.audio_output;
                         // Get the next packet from the format reader.
                         let packet = match reader.next_packet() {
@@ -285,12 +308,25 @@ fn main() {
                             &mut decoder,
                             seek_timestamp,
                         );
-                        state = PlayerState::Playing;
 
-                        // Update UI with playing state to ensure synchronization
-                        ui_tx
-                            .send(UiCommand::PlaybackStateChanged(true))
-                            .expect("Failed to send playback state to ui thread");
+                        // Check if the load was successful before proceeding
+                        if audio_engine_state.reader.is_some()
+                            && audio_engine_state.track_info.is_some()
+                        {
+                            state = PlayerState::Playing;
+
+                            // Update UI with playing state to ensure synchronization
+                            ui_tx
+                                .send(UiCommand::PlaybackStateChanged(true))
+                                .expect("Failed to send playback state to ui thread");
+                        } else {
+                            // Loading failed during seek - notify UI and set to stopped
+                            tracing::warn!("Failed to reload audio file during seek");
+                            ui_tx
+                                .send(UiCommand::AudioFinished)
+                                .expect("Failed to send audio finished to ui thread");
+                            state = PlayerState::Stopped;
+                        }
                     }
                 }
                 PlayerState::LoadFile(ref path) => {
@@ -310,12 +346,26 @@ fn main() {
 
                     current_track_path = Some((*path).clone());
                     load_file(path, &mut audio_engine_state, &mut decoder, 0);
-                    // TODO - Get total u64 track duration and send to Ui
-                    ui_tx
-                        .send(UiCommand::TotalTrackDuration(audio_engine_state.duration))
-                        .expect("Failed to send play to audio thread");
 
-                    state = PlayerState::Playing;
+                    // Check if the load was successful before proceeding
+                    if audio_engine_state.reader.is_some()
+                        && audio_engine_state.track_info.is_some()
+                    {
+                        // TODO - Get total u64 track duration and send to Ui
+                        ui_tx
+                            .send(UiCommand::TotalTrackDuration(audio_engine_state.duration))
+                            .expect("Failed to send play to audio thread");
+
+                        state = PlayerState::Playing;
+                    } else {
+                        // Loading failed - notify UI and set to stopped
+                        tracing::warn!("Failed to load audio file: {:?}", path);
+                        ui_tx
+                            .send(UiCommand::AudioFinished)
+                            .expect("Failed to send audio finished to ui thread");
+                        state = PlayerState::Stopped;
+                        current_track_path = None;
+                    }
                 }
                 PlayerState::Paused => {
                     std::thread::sleep(std::time::Duration::from_millis(50));
@@ -532,11 +582,41 @@ fn load_file(
             audio_engine_state.seek = seek;
 
             // Configure everything for playback.
-            _ = setup_audio_reader(audio_engine_state);
+            if let Err(err) = setup_audio_reader(audio_engine_state) {
+                tracing::warn!("Failed to setup audio reader: {}", err);
+                // Reset the audio engine state to prevent crashes
+                audio_engine_state.reader = None;
+                audio_engine_state.track_info = None;
+                audio_engine_state.decode_opts = None;
+                audio_engine_state.seek = None;
+                audio_engine_state.duration = 0;
+                *decoder = None;
+                return;
+            }
 
-            let reader = audio_engine_state.reader.as_mut().unwrap();
-            let play_opts = audio_engine_state.track_info.unwrap();
-            let decode_opts = audio_engine_state.decode_opts.unwrap();
+            let reader = match audio_engine_state.reader.as_mut() {
+                Some(reader) => reader,
+                None => {
+                    tracing::warn!("Reader is None after setup");
+                    return;
+                }
+            };
+
+            let play_opts = match audio_engine_state.track_info {
+                Some(opts) => opts,
+                None => {
+                    tracing::warn!("Track info is None after setup");
+                    return;
+                }
+            };
+
+            let decode_opts = match audio_engine_state.decode_opts {
+                Some(opts) => opts,
+                None => {
+                    tracing::warn!("Decode opts is None after setup");
+                    return;
+                }
+            };
 
             let track = match reader
                 .tracks()
@@ -577,7 +657,16 @@ fn load_file(
         Err(err) => {
             // The input was not supported by any format reader.
             tracing::warn!("the audio format is not supported: {}", err);
-            // Err(err);
+
+            // Reset the audio engine state to prevent crashes
+            audio_engine_state.reader = None;
+            audio_engine_state.track_info = None;
+            audio_engine_state.decode_opts = None;
+            audio_engine_state.seek = None;
+            audio_engine_state.duration = 0;
+
+            // Clear any existing decoder
+            *decoder = None;
         }
     }
 }
@@ -585,7 +674,13 @@ fn load_file(
 fn setup_audio_reader(audio_engine_state: &mut AudioEngineState) -> Result<i32> {
     // If the user provided a track number, select that track if it exists, otherwise, select the
     // first track with a known codec.
-    let reader = audio_engine_state.reader.as_mut().unwrap();
+    let reader = match audio_engine_state.reader.as_mut() {
+        Some(reader) => reader,
+        None => {
+            tracing::warn!("No reader available in setup_audio_reader");
+            return Err(Error::Unsupported("No reader available"));
+        }
+    };
     let seek = &audio_engine_state.seek;
 
     let track = audio_engine_state
@@ -616,7 +711,12 @@ fn setup_audio_reader(audio_engine_state: &mut AudioEngineState) -> Result<i32> 
             Err(Error::ResetRequired) => {
                 tracing::warn!("reset required...");
                 // print_tracks(reader.tracks());
-                track_id = first_supported_track(reader.tracks()).unwrap().id;
+                if let Some(track) = first_supported_track(reader.tracks()) {
+                    track_id = track.id;
+                } else {
+                    tracing::warn!("No supported tracks found after reset");
+                    return Err(Error::Unsupported("No supported tracks after reset"));
+                }
                 0
             }
             Err(err) => {


### PR DESCRIPTION
- Replace unwrap() calls with proper error handling in audio thread
- Add graceful fallback when audio format is not supported or corrupted
- Reset audio engine state on load failures to prevent inconsistent state
- Handle SendError in player methods when audio thread dies
- Auto-skip to next track when current track fails to load
- Add support for additional audio formats (FLAC, WAV, AAC, OGG, Vorbis)

Fixes panic when clicking play on unsupported/corrupted MP3 files. The app now logs warnings and continues playback with the next available track.